### PR TITLE
Switch brew-publish to leverage homebrew's own bump-formula-pr command

### DIFF
--- a/bin/brew-publish
+++ b/bin/brew-publish
@@ -37,4 +37,4 @@ if [ -z "$checksum" ]; then
 fi
 
 
-HOMEBREW_DEVELOPER=true brew bump-formula-pr "$brew_name"
+HOMEBREW_DEVELOPER=true brew bump-formula-pr --url="$url" --sha256="$checksum" "$brew_name"

--- a/bin/brew-publish
+++ b/bin/brew-publish
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Usage: script/brew-publish <name> <version> [-g <gh-project>] [-t <homebrew-tap>] [-r [<homebrew-remote>]]
+# Usage: script/brew-publish <name> <version> [-g <gh-project>] [-r [<homebrew-remote>]]
 #
 # Updates the `<name>.rb` Homebrew formula to `<version>` and sends a pull
 # request with the change.
@@ -12,14 +12,12 @@ abort() {
 
 brew_name="${1?Formula name is required.}"
 version="${2?Formula version is required.}"
-brew_dir="homebrew/homebrew-core/Formula"
 shift 2
 
-while getopts ":g:rt:" opt; do
+while getopts ":g:r" opt; do
   case $opt in
   g) gh_project="github.com/${OPTARG}" ;;
   r) brew_remote="${OPTARG:-origin}" ;;
-  t) brew_dir="${OPTARG}" ;;
   :) abort "Option -$OPTARG requires an argument." ;;
   \?) abort "Invalid option: -$OPTARG" ;;
   esac

--- a/bin/brew-publish
+++ b/bin/brew-publish
@@ -23,10 +23,6 @@ while getopts ":g:r" opt; do
   esac
 done
 
-if ! type -p hub >/dev/null; then
-  abort "ERROR: You have to install hub to proceed."
-fi
-
 if [ -z "$gh_project" ]; then
   gh_project="$(git remote -v | grep '^origin' | grep -oE 'github.com[:/][^/]+/[^/ ]+' | head -1)"
   gh_project="${gh_project%.git}"

--- a/bin/brew-publish
+++ b/bin/brew-publish
@@ -42,27 +42,5 @@ if [ -z "$checksum" ]; then
   abort "ERROR: calculating the checksum failed for $url"
 fi
 
-pushd "$(brew --prefix)/Library/Taps/${brew_dir}"
 
-git fetch -q --unshallow origin master 2>/dev/null || git fetch -q origin master
-
-branch="${brew_name}-${version}"
-git checkout -q -B "$branch" origin/master
-
-formula="${brew_name}.rb"
-sed -i.bak -E "
-  s!^(  url ).+!\\1\"${url}\"!
-  s!^(  sha256 ).+!\\1\"${checksum}\"!
-" "$formula"
-rm -f "${formula}.bak"
-
-git commit -m "${brew_name} ${version#v}" -- "$formula"
-
-if [ -z "$brew_remote" ]; then
-  # hackish way of getting the git remote name for user's fork
-  brew_remote="$(hub fork 2>&1 | grep -oE 'remote:? \S+' | tail -1 | awk '{print $2}')"
-fi
-git push -u "$brew_remote" HEAD
-hub pull-request -m "${brew_name} ${version#v}"
-
-git checkout -q -
+HOMEBREW_DEVELOPER=true brew bump-formula-pr "$brew_name"

--- a/bin/brew-publish
+++ b/bin/brew-publish
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Usage: script/brew-publish <name> <version> [-g <gh-project>] [-r [<homebrew-remote>]]
+# Usage: script/brew-publish <name> <version> [-g <gh-project>]
 #
 # Updates the `<name>.rb` Homebrew formula to `<version>` and sends a pull
 # request with the change.
@@ -14,10 +14,9 @@ brew_name="${1?Formula name is required.}"
 version="${2?Formula version is required.}"
 shift 2
 
-while getopts ":g:r" opt; do
+while getopts ":g:" opt; do
   case $opt in
   g) gh_project="github.com/${OPTARG}" ;;
-  r) brew_remote="${OPTARG:-origin}" ;;
   :) abort "Option -$OPTARG requires an argument." ;;
   \?) abort "Invalid option: -$OPTARG" ;;
   esac

--- a/bin/brew-publish
+++ b/bin/brew-publish
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# Usage: script/brew-publish <name> <version> [-g <gh-project>]
+# Usage: script/brew-publish <name> <version> [-g <gh-project>] [-n]
+#
+#    -n    dry-run
 #
 # Updates the `<name>.rb` Homebrew formula to `<version>` and sends a pull
 # request with the change.
@@ -14,9 +16,10 @@ brew_name="${1?Formula name is required.}"
 version="${2?Formula version is required.}"
 shift 2
 
-while getopts ":g:" opt; do
+while getopts ":g:n" opt; do
   case $opt in
   g) gh_project="github.com/${OPTARG}" ;;
+  n) dryrun=--dry-run; set -x ;;
   :) abort "Option -$OPTARG requires an argument." ;;
   \?) abort "Invalid option: -$OPTARG" ;;
   esac
@@ -35,5 +38,4 @@ if [ -z "$checksum" ]; then
   abort "ERROR: calculating the checksum failed for $url"
 fi
 
-
-HOMEBREW_DEVELOPER=true brew bump-formula-pr --url="$url" --sha256="$checksum" "$brew_name"
+HOMEBREW_DEVELOPER=true brew bump-formula-pr "$dryrun" --url="$url" --sha256="$checksum" "$brew_name"

--- a/bin/brew-publish
+++ b/bin/brew-publish
@@ -38,4 +38,4 @@ if [ -z "$checksum" ]; then
   abort "ERROR: calculating the checksum failed for $url"
 fi
 
-HOMEBREW_DEVELOPER=true brew bump-formula-pr "$dryrun" --url="$url" --sha256="$checksum" "$brew_name"
+HOMEBREW_DEVELOPER=true brew bump-formula-pr $dryrun --url="$url" --sha256="$checksum" "$brew_name"


### PR DESCRIPTION
This branch has been tested and was used for this bump:
https://github.com/nodenv/homebrew-nodenv/pull/23
